### PR TITLE
chore(release): v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.3](https://github.com/getoriginal/original-js/compare/v1.1.2...v1.1.3) (2023-11-13)
+
+
+### Bug Fixes
+
+* display type on assetData attributes is optional ([1d093b3](https://github.com/getoriginal/original-js/commit/1d093b391ef01b319c1a63d722462b86e592d179))
+
 ### [1.1.2](https://github.com/getoriginal/original-js/compare/v1.1.1...v1.1.2) (2023-11-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "original-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Original SDK for js",
   "repository": "https://github.com/getoriginal/original-js.git",
   "author": "Original",

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export type AssetData = {
   name: string;
   store_image_on_ipfs: boolean;
   unique_name: boolean;
-  attributes?: { display_type: string; trait_type: string; value: string }[];
+  attributes?: { trait_type: string; value: string; display_type?: string }[];
   description?: string;
   external_url?: string;
 };


### PR DESCRIPTION
### [1.1.3](https://github.com/getoriginal/original-js/compare/v1.1.2...v1.1.3) (2023-11-13)


### Bug Fixes

* display type on assetData attributes is optional ([1d093b3](https://github.com/getoriginal/original-js/commit/1d093b391ef01b319c1a63d722462b86e592d179))