### PR TITLE
fix: [ORI-1872] export alias OriginalClient with backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ Import the sdk with using commonjs or es6 imports.
 Read the full [Original API documentation](https://docs.getoriginal.com).
 
 ```typescript
-const { Original } = require('original-sdk');
+const { OriginalClient } = require('original-sdk');
 //or
-import { Original } from 'original-sdk';
+import { OriginalClient } from 'original-sdk';
 ```
 
 Create a new instance of the Original client by passing in your api key and api key secret.
 
 ```typescript
-const client = new Original('YOUR_API_KEY', 'API_KEY_SECRET');
+const client = new OriginalClient('YOUR_API_KEY', 'API_KEY_SECRET');
 ```
 
 ### User

--- a/src/client.ts
+++ b/src/client.ts
@@ -38,7 +38,7 @@ export class Original {
    * @param {string} [secret] - the api secret
    * @param {OriginalOptions} [options] - additional options, here you can pass custom options to axios instance
    * @example <caption>initialize the client</caption>
-   * new Original('api_key', 'secret')
+   * new OriginalClient('api_key', 'secret')
    */
 
   constructor(apiKey: string, secret: string, options?: OriginalOptions) {
@@ -341,3 +341,5 @@ export class Original {
     return await this._get<APIResponse<Deposit>>('deposit', { user_uid: userUid });
   }
 }
+
+export const OriginalClient = Original;

--- a/test/sdk/client.js
+++ b/test/sdk/client.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { Original, Environment } from '../../dist/';
+import { Original, OriginalClient, Environment } from '../../dist/';
 import { verify } from 'jsonwebtoken';
 
 const expect = chai.expect;
@@ -11,23 +11,30 @@ describe('Original sdk tests', async () => {
 	const apiKey = process.env.API_KEY;
 	const apiSecret = process.env.API_SECRET;
 
-	it('sets baseURL when constructed with baseURL config', () => {
+	it('is backwards compatible with Original and OriginalClient', () => {
+		const originalClient = new OriginalClient(apiKey, apiSecret, { baseURL: 'http://localhost:3004' });
 		const original = new Original(apiKey, apiSecret, { baseURL: 'http://localhost:3004' });
+		expect(originalClient).instanceof(OriginalClient);
+		expect(original).instanceof(OriginalClient);
+	});
+
+	it('sets baseURL when constructed with baseURL config', () => {
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: 'http://localhost:3004' });
 		expect(original.baseURL).to.equal('http://localhost:3004');
 	});
 
 	it('sets baseURL dependent on environment in config, production', () => {
-		const original = new Original(apiKey, apiSecret, { env: Environment.Production });
+		const original = new OriginalClient(apiKey, apiSecret, { env: Environment.Production });
 		expect(original.baseURL).to.equal('https://api.getoriginal.com/v1');
 	});
 
 	it('sets baseURL when no env or baseURL arguments are passed', () => {
-		const original = new Original(apiKey, apiSecret);
+		const original = new OriginalClient(apiKey, apiSecret);
 		expect(original.baseURL).to.equal('https://api.getoriginal.com/v1');
 	});
 
 	it('jwt token is valid', () => {
-		const original = new Original(apiKey, apiSecret);
+		const original = new OriginalClient(apiKey, apiSecret);
 		const token = original.tokenManager.getToken();
 		expect(
 			verify(token, apiSecret, function (err, decoded) {

--- a/test/sdk/e2e.js
+++ b/test/sdk/e2e.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const { Original } = require('../../dist');
+const { OriginalClient } = require('../../dist');
 const randomString = require('randomstring');
 
 const expect = chai.expect;
@@ -37,31 +37,31 @@ describe('Original sdk e2e-method tests', async () => {
 	};
 
 	it('gets user by uid', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getUser(mintToUserUid);
 		expect(response.data.client_id).to.equal(mintToUserClientId);
 	});
 
 	it('gets user by email', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getUserByEmail(mintToUserEmail);
 		expect(response.data.email).to.equal(mintToUserEmail);
 	});
 
 	it('gets user by client_id', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getUserByClientId(mintToUserClientId);
 		expect(response.data.email).to.equal(mintToUserEmail);
 	});
 
 	it('get user by email does not fail when no query results', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getUserByEmail('randomnotfound@test.com');
 		expect(response.data).to.equal(null);
 	});
 
 	it('get user not found throws error', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		await expectThrowsAsync(
 			() => original.getUser('notfound'),
 			'Original error code 404: client_error: {"code":"not_found","message":"User not found."}',
@@ -70,7 +70,7 @@ describe('Original sdk e2e-method tests', async () => {
 
 	it('creates user', async () => {
 		const clientId = randomString.generate(8);
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.createUser({
 			email: `${clientId}@test.com`,
 			client_id: clientId,
@@ -80,7 +80,7 @@ describe('Original sdk e2e-method tests', async () => {
 
 	it('handles error on creates user', async () => {
 		const clientId = 'existing_client';
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		await expectThrowsAsync(
 			() =>
 				original.createUser({
@@ -92,13 +92,13 @@ describe('Original sdk e2e-method tests', async () => {
 	});
 
 	it('gets asset by uid', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getAsset(getAssetUid);
 		expect(response.data.uid).to.equal(getAssetUid);
 	});
 
 	it('gets assets by user uid', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const usersAssets = await original.getAssetsByUserUid(mintToUserUid);
 		const assetUid = usersAssets.data[0].uid;
 		const response = await original.getAsset(assetUid);
@@ -107,7 +107,7 @@ describe('Original sdk e2e-method tests', async () => {
 
 	it('gets assets/transfers/burns by user uid return empty arrays', async () => {
 		const clientId = randomString.generate(8);
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const userResponse = await original.createUser({
 			email: `${clientId}@test.com`,
 			client_id: clientId,
@@ -123,7 +123,7 @@ describe('Original sdk e2e-method tests', async () => {
 	});
 
 	it('gets transfer by user uid', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const usersTransfers = await original.getTransfersByUserUid(mintToUserUid);
 		const transferUid = usersTransfers.data[0].uid;
 		const response = await original.getTransfer(transferUid);
@@ -131,7 +131,7 @@ describe('Original sdk e2e-method tests', async () => {
 	});
 
 	it('queries and gets burn', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const userBurns = await original.getBurnsByUserUid(burnUserUid);
 		const burnUid = userBurns.data[0].uid;
 		const response = await original.getBurn(burnUid);
@@ -139,13 +139,13 @@ describe('Original sdk e2e-method tests', async () => {
 	});
 
 	it('get collection', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getCollection(nonEditableCollectionUid);
 		expect(response.data.uid).to.equal(nonEditableCollectionUid);
 	});
 
 	it('get deposit address', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getDeposit(transferToUserUid);
 		expect(response.data.wallet_address).to.equal(transferToUserWallet);
 		expect(response.data.network).to.equal(ACCEPTANCE_NETWORK);
@@ -153,7 +153,7 @@ describe('Original sdk e2e-method tests', async () => {
 	});
 
 	it('edits asset in an editable collection', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const assetName = randomString.generate(8);
 		const asset_data = {
 			name: assetName,
@@ -190,7 +190,7 @@ describe('Original sdk e2e-method tests', async () => {
 	});
 
 	it('creates asset, transfer, and burn flow', async () => {
-		const original = new Original(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const assetName = randomString.generate(8);
 		const asset_data = {
 			name: assetName,


### PR DESCRIPTION
- We want to sync naming convention across sdks
-  Export OriginalClient as alias for Original, keeping both uses functional
- Add tests 