### PR TITLE
feat: [ORI-1880] Add development environment and URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Why
+
+### How
+
+### How Has This Been Tested?
+
+### Checklist

--- a/README.md
+++ b/README.md
@@ -48,11 +48,22 @@ const { OriginalClient } = require('original-sdk');
 import { OriginalClient } from 'original-sdk';
 ```
 
-Create a new instance of the Original client by passing in your api key and api key secret.
+Create a new instance of the Original client by passing in your api key and api secret with
+the environment associated with that app.
+
+Development:
 
 ```typescript
-const client = new OriginalClient('YOUR_API_KEY', 'API_KEY_SECRET');
+const client = new OriginalClient('YOUR_DEV_APP_API_KEY', 'YOUR_DEV_APP_SECRET', { env: Environment.Development });
 ```
+
+Production:
+
+```typescript
+const client = new OriginalClient('YOUR_PROD_APP_API_KEY', 'YOUR_PROD_APP_SECRET', { env: Environment.Production });
+```
+
+NOTE: If you do not pass the environment, it will default to Production.
 
 ### User
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "compile": "rollup -c",
     "changelog": "standard-version --skip.tag --skip.commit --tag-prefix=v",
     "commitlinter": "commitlint",
-    "build": "rm -rf dist && yarn run types && yarn run compile",
+    "build": "rm -rf dist && yarn run types && yarn lint-fix && yarn run compile",
     "types": "tsc --emitDeclarationOnly true",
     "prettier": "prettier --check '**/*.{js,ts,md,css,scss,json}' .eslintrc.json .prettierrc .babelrc",
     "prettier-fix": "npx prettier --write '**/*.{js,ts,md,css,scss,json}' .eslintrc.json .prettierrc .babelrc",

--- a/src/client.ts
+++ b/src/client.ts
@@ -65,8 +65,7 @@ export class Original {
   getEnvURL(env: string) {
     if (env === Environment.Development) {
       return DEVELOPMENT_URL;
-    } else
-    if (env === Environment.Production) {
+    } else if (env === Environment.Production) {
       return PRODUCTION_URL;
     } else {
       throw new Error('Invalid environment');

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,6 +21,7 @@ import {
 import { isErrorResponse } from './error';
 import { TokenManager } from './token_manager';
 
+const DEVELOPMENT_URL = 'https://api-dev.getoriginal.com/v1';
 const PRODUCTION_URL = 'https://api.getoriginal.com/v1';
 
 export class Original {
@@ -45,8 +46,8 @@ export class Original {
     if (!apiKey || !secret) {
       throw new Error('apiKey and secret are required');
     }
-    this.secret = secret;
     this.apiKey = apiKey;
+    this.secret = secret;
 
     this.tokenManager = new TokenManager(this.apiKey, this.secret);
     const configOptions = options ? options : {};
@@ -62,6 +63,9 @@ export class Original {
   }
 
   getEnvURL(env: string) {
+    if (env === Environment.Development) {
+      return DEVELOPMENT_URL;
+    } else
     if (env === Environment.Production) {
       return PRODUCTION_URL;
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,5 +131,5 @@ export type UidResponse = { uid: string };
 
 export enum Environment {
   Development = 'development',
-  Production = 'production'
+  Production = 'production',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,5 +130,6 @@ export type APIResponse<T> = { data: T; success: boolean };
 export type UidResponse = { uid: string };
 
 export enum Environment {
-  Production = 'production',
+  Development = 'development',
+  Production = 'production'
 }

--- a/test/sdk/client.js
+++ b/test/sdk/client.js
@@ -23,6 +23,11 @@ describe('Original sdk tests', async () => {
 		expect(original.baseURL).to.equal('http://localhost:3004');
 	});
 
+	it('sets baseURL dependent on environment in config, development', () => {
+		const original = new OriginalClient(apiKey, apiSecret, { env: Environment.Development });
+		expect(original.baseURL).to.equal('https://api-dev.getoriginal.com/v1');
+	});
+
 	it('sets baseURL dependent on environment in config, production', () => {
 		const original = new OriginalClient(apiKey, apiSecret, { env: Environment.Production });
 		expect(original.baseURL).to.equal('https://api.getoriginal.com/v1');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,14 +2073,6 @@ caniuse-lite@^1.0.30001541:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001543.tgz#478a3e9dddbb353c5ab214b0ecb0dbed529ed1d8"
   integrity sha512-qxdO8KPWPQ+Zk6bvNpPeQIOH47qZSYdFZd6dXQzb2KzhnSXju4Kd7H1PkSJx6NICSMgo/IhRZRhhfPTHYpJUCA==
 
-casual@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/casual/-/casual-1.6.2.tgz#f56b87113ae99a6bba45e04bdfa068ca443f9e85"
-  integrity sha512-NQObL800rg32KZ9bBajHbyDjxLXxxuShChQg7A4tbSeG3n1t7VYGOSkzFSI9gkSgOHp+xilEJ7G0L5l6M30KYA==
-  dependencies:
-    mersenne-twister "^1.0.1"
-    moment "^2.15.2"
-
 chai-arrays@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/chai-arrays/-/chai-arrays-2.2.0.tgz#571479cbc5eca81605ed4eed1e8a2a28552d2a25"
@@ -4325,11 +4317,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mersenne-twister@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
-  integrity sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA==
-
 micromark@~2.11.0:
   version "2.11.4"
   resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
@@ -4418,11 +4405,6 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment@^2.15.2:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## Why
- Development apps will soon need to use a different URL to that of production apps.

### How
- Add development environment enum/url
- Default will remain as production for back compatibility
- Updated readme

### How Has This Been Tested?
- Locally

### Checklist
