### PR TITLE
fix: [ORI-1932] Add specific error classes for the types of errors we can receive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 17, 18]
+        node: [16]
     steps:
       - uses: actions/checkout@v3
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -69,8 +69,8 @@ export function throwErrorFromResponse(res: AxiosResponse<APIErrorResponse>) {
   } else if (errorType === OriginalErrorCode.validationError) {
     throw new ValidationError(errorMessage, errorStatus, errorData);
   } else {
-    // TODO: We should extract the original Axios Error and throw it.
-    throw new Error(errorMessage);
+    // Likely a client axios error (Not Found, Forbidden, etc)
+    throw new ClientError(errorMessage, errorStatus, res?.statusText);
   }
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,81 @@
 import { AxiosResponse } from 'axios';
-import { APIErrorResponse } from './types';
+
+export enum OriginalErrorCode {
+  clientError = 'client_error',
+  serverError = 'server_error',
+  validationError = 'validation_error',
+}
+
+export type ErrorResponseDetail = {
+  code: OriginalErrorCode;
+  message: string;
+  field_name?: string;
+};
+
+export type APIErrorResponse = {
+  success: boolean;
+  error?: {
+    detail: ErrorResponseDetail | ErrorResponseDetail[];
+    type: OriginalErrorCode;
+  }
+};
+
+export class OriginalError extends Error {
+  status: number;
+  data: unknown;
+  code: OriginalErrorCode;
+
+  constructor(message: string, status: number, data: unknown, code: OriginalErrorCode) {
+    super(message);
+    this.status = status;
+    this.data = data;
+    this.code = code;
+  }
+}
+
+export class ClientError extends OriginalError {
+  constructor(message: string, status: number, data: unknown) {
+    super(message, status, data, OriginalErrorCode.clientError);
+  }
+}
+
+export class ServerError extends OriginalError {
+  constructor(message: string, status: number, data: unknown) {
+    super(message, status, data, OriginalErrorCode.serverError);
+  }
+}
+
+export class ValidationError extends OriginalError {
+  constructor(message: string, status: number, data: unknown) {
+    super(message, status, data, OriginalErrorCode.validationError);
+  }
+}
 
 export function isErrorResponse(res: AxiosResponse<unknown>): res is AxiosResponse<APIErrorResponse> {
-  return !res.status || res.status < 200 || 300 <= res.status;
+  // Consider only client errors (400-499) and server errors (500-599) as errors.
+  return res.status < 200 || res.status >= 400;
 }
+
+export function throwErrorFromResponse(res: AxiosResponse<APIErrorResponse>) {
+  const errorType = res?.data?.error?.type;
+  const errorStatus = res?.status;
+  const errorMessage = getFirstErrorDetailMessage(res?.data?.error?.detail);
+  const errorData = res?.data;
+
+  if (errorType === OriginalErrorCode.clientError) {
+    throw new ClientError(errorMessage, errorStatus, errorData);
+  } else if (errorType === OriginalErrorCode.serverError) {
+    throw new ServerError(errorMessage, errorStatus, errorData);
+  } else if (errorType === OriginalErrorCode.validationError) {
+    throw new ValidationError(errorMessage, errorStatus, errorData);
+  } else {
+    throw new Error(errorMessage);
+  }
+}
+
+const getFirstErrorDetailMessage = (detail: ErrorResponseDetail[] | ErrorResponseDetail | undefined) => {
+  if (Array.isArray(detail)) {
+    return detail[0].message ?? 'Unknown error';
+  }
+  return detail?.message ?? 'Unknown error';
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,29 +1,8 @@
-import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosRequestConfig } from 'axios';
 
 export type OriginalOptions = AxiosRequestConfig & {
   env?: Environment;
 };
-
-type ErrorResponseDetails = {
-  code: number;
-  message: string[];
-};
-
-type ErrorResponseOriginalError = {
-  detail: ErrorResponseDetails;
-  type: string;
-};
-
-export type APIErrorResponse = {
-  success: boolean;
-  error?: ErrorResponseOriginalError;
-};
-
-export class ErrorFromResponse<T> extends Error {
-  code?: number;
-  response?: AxiosResponse<T>;
-  status?: number;
-}
 
 export type UserParams = { client_id: string; email: string };
 

--- a/test/sdk/e2e.js
+++ b/test/sdk/e2e.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const { OriginalClient } = require('../../dist');
+const { OriginalClient, OriginalError, ClientError, ValidationError } = require('../../dist');
 const randomString = require('randomstring');
 
 const expect = chai.expect;
@@ -22,19 +22,6 @@ describe('Original sdk e2e-method tests', async () => {
 	const nonEditableCollectionUid = process.env.NON_EDITABLE_COLLECTION_UID;
 	const editableCollectionUid = process.env.EDITABLE_COLLECTION_UID;
 	const acceptanceEndpoint = process.env.ACCEPTANCE_ENDPOINT;
-
-	const expectThrowsAsync = async (method, errorMessage) => {
-		let error = null;
-		try {
-			await method();
-		} catch (err) {
-			error = err;
-		}
-		expect(error).to.be.an('Error');
-		if (errorMessage) {
-			expect(error.message).to.equal(errorMessage);
-		}
-	};
 
 	it('gets user by uid', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
@@ -60,12 +47,28 @@ describe('Original sdk e2e-method tests', async () => {
 		expect(response.data).to.equal(null);
 	});
 
-	it('get user not found throws error', async () => {
+	it('get user not found throws validation error', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
-		await expectThrowsAsync(
-			() => original.getUser('notfound'),
-			'Original error code 404: client_error: {"code":"not_found","message":"User not found."}',
-		);
+		try {
+			await original.getUser('');
+			expect.fail('getUser should have thrown an error');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.equal('Not Found');
+		}
+	});
+
+	it('get user not found throws client error', async () => {
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		try {
+			await original.getUser('notfound');
+			expect.fail('getUser should have thrown an error');
+		} catch (error) {
+			expect(error).to.be.instanceOf(OriginalError);
+			expect(error).to.be.instanceOf(ClientError);
+			expect(error.status).to.equal(404);
+			expect(error.message).to.equal('User not found.');
+		}
 	});
 
 	it('creates user', async () => {
@@ -78,17 +81,38 @@ describe('Original sdk e2e-method tests', async () => {
 		expect(response.data.uid).to.exist;
 	});
 
-	it('handles error on creates user', async () => {
+	it('handles validation error on create user', async () => {
+		const clientId = randomString.generate(8);
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		try {
+			await original.createUser({
+				email: `invalid_email`,
+				client_id: clientId,
+			});
+			expect.fail('createUser should have thrown an error');
+		} catch (error) {
+			expect(error).to.be.instanceOf(OriginalError);
+			expect(error).to.be.instanceOf(ValidationError);
+			expect(error.status).to.equal(400);
+			expect(error.message).to.equal('Enter a valid email address.');
+		}
+	});
+
+	it('handles client error on create user', async () => {
 		const clientId = 'existing_client';
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
-		await expectThrowsAsync(
-			() =>
-				original.createUser({
-					email: `${clientId}@test.com`,
-					client_id: clientId,
-				}),
-			'Original error code 400: client_error: {"code":"bad_request","message":"User already exists."}',
-		);
+		try {
+			await original.createUser({
+				email: `${clientId}@test.com`,
+				client_id: clientId,
+			});
+			expect.fail('createUser should have thrown an error');
+		} catch (error) {
+			expect(error).to.be.instanceOf(OriginalError);
+			expect(error).to.be.instanceOf(ClientError);
+			expect(error.status).to.equal(400);
+			expect(error.message).to.equal('User already exists.');
+		}
 	});
 
 	it('gets asset by uid', async () => {

--- a/test/sdk/e2e.js
+++ b/test/sdk/e2e.js
@@ -47,13 +47,13 @@ describe('Original sdk e2e-method tests', async () => {
 		expect(response.data).to.equal(null);
 	});
 
-	it('get user not found throws validation error', async () => {
+	it('get user with empty params throws a client not found error', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		try {
 			await original.getUser('');
 			expect.fail('getUser should have thrown an error');
 		} catch (error) {
-			expect(error).to.be.instanceOf(Error);
+			expect(error).to.be.instanceOf(ClientError);
 			expect(error.message).to.equal('Not Found');
 		}
 	});


### PR DESCRIPTION
## Why
- As a user, I may want to handle specific error types
- Codes such as 3xx was being considered an error, when it could be a redirect (not necessarily an error)

### How
- Provide error classes for the different error types we provide.
- Align errors and types with the backend.
- Move error related code to error files
- Consider 400-499 and 500-599 to be errors

### How Has This Been Tested?
- Locally (tests to follow in separate PR)

### Checklist
Now we should be getting full detailed error messages that can be handled such as:
```
ValidationError: Enter a valid email address.
    at throwErrorFromResponse (webpack-internal:///(api)/../original-js/dist/index.js:101:11)
    at Original.handleResponse (webpack-internal:///(api)/../original-js/dist/index.js:294:15)
    at _callee$ (webpack-internal:///(api)/../original-js/dist/index.js:226:54)
    at tryCatch (webpack-internal:///(api)/../original-js/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:45:16)
    at Generator.eval (webpack-internal:///(api)/../original-js/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:133:17)
    at Generator.eval [as throw] (webpack-internal:///(api)/../original-js/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:74:21)
    at asyncGeneratorStep (webpack-internal:///(api)/../original-js/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _throw (webpack-internal:///(api)/../original-js/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  status: 400,
  data: {
    success: false,
    error: { type: 'validation_error', detail: [Object] }
  },
  code: 'validation_error'
}
```