### PR TITLE
fix(ORI-2191): make client_id optional, add missing metadata params

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,10 +31,10 @@ export type AssetData = {
 };
 
 export type AssetParams = {
-  client_id: string;
   collection_uid: string;
   data: AssetData;
   user_uid: string;
+  client_id?: string;
 };
 
 export type EditAssetData = {
@@ -50,12 +50,22 @@ export type EditAssetParams = {
   data: EditAssetData;
 };
 
+export type AssetMetadata = {
+  attributes?: { trait_type: string; value: string; display_type?: string }[];
+  description?: string;
+  external_url?: string;
+  image_url?: string;
+  name?: string;
+  org_image_url?: string;
+  original_id?: string;
+}
+
 export type Asset = {
-  client_id: string;
   collection_name: string;
   collection_uid: string;
   created_at: string;
   is_burned: boolean;
+  is_editing: boolean;
   is_minted: boolean;
   is_transferable: boolean;
   is_transferring: boolean;
@@ -63,8 +73,9 @@ export type Asset = {
   name: string;
   token_id: string;
   uid: string;
+  client_id?: string | null;
   explorer_url?: string;
-  metadata?: string;
+  metadata?: string | AssetMetadata;
   owner_address?: string;
   owner_user_uid?: string;
   token_uri?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,13 +51,13 @@ export type EditAssetParams = {
 };
 
 export type AssetMetadata = {
+  image_url: string;
+  name: string;
+  org_image_url: string;
+  original_id: string;
   attributes?: { trait_type: string; value: string; display_type?: string }[];
   description?: string;
   external_url?: string;
-  image_url?: string;
-  name?: string;
-  org_image_url?: string;
-  original_id?: string;
 }
 
 export type Asset = {

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -182,6 +182,30 @@ describe('Original sdk e2e-method tests', async () => {
 		expect(response.data.chain_id).to.equal(ACCEPTANCE_CHAIN_ID);
 	});
 
+	it('creates an asset without client id', async () => {
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const assetName = randomString.generate(8);
+		const asset_data = {
+			name: assetName,
+			unique_name: true,
+			image_url: 'https://example.com/image.png',
+			store_image_on_ipfs: false,
+			description: 'test description',
+			attributes: [
+				{ trait_type: 'Eyes', value: 'Green' },
+				{ trait_type: 'Hair', value: 'Black' },
+			],
+		};
+		const request_data = {
+			data: asset_data,
+			user_uid: mintToUserUid,
+			collection_uid: editableCollectionUid,
+		};
+		const assetResponse = await original.createAsset(request_data);
+		const assetUid = assetResponse.data.uid;
+		expect(assetUid).to.exist;
+	});
+
 	it('edits asset in an editable collection', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const assetName = randomString.generate(8);


### PR DESCRIPTION
## Why
- Client ID needs to be made optional in asset params
- Fix metadata typing when getting an asset.

### How
- Adjust types

### How Has This Been Tested?
- Locally

### Checklist
