### PR TITLE
feat(ORI-1755): add reward methods to sdk

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -31,5 +31,10 @@ jobs:
           TRANSFER_TO_USER_UID: ${{secrets.TRANSFER_TO_USER_UID}}
           ASSET_UID: ${{secrets.ASSET_UID}}
           NON_EDITABLE_COLLECTION_UID: ${{secrets.NON_EDITABLE_COLLECTION_UID}}
+          ALLOCATION_UID: ${{secrets.ALLOCATION_UID}}
+          CLAIM_UID: ${{secrets.CLAIM_UID}}
+          REWARD_UID: ${{secrets.REWARD_UID}}
+          USER_UID: ${{secrets.USER_UID}}
+          CLAIM_TO_ADDRESS: ${{secrets.CLAIM_TO_ADDRESS}}
           EDITABLE_COLLECTION_UID: ${{secrets.EDITABLE_COLLECTION_UID}}
           ACCEPTANCE_ENDPOINT: ${{secrets.ACCEPTANCE_ENDPOINT}}

--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ const rewardDetails = response.data;
         token_name: "TestnetORI",
         created_at: "2024-02-13T10:45:56.952745Z",
         contract_address: "0x124a6755ee787153bb6228463d5dc3a02890a7db",
+        withdraw_receiver: "0x4881ab2f73c48a54b907a8b697b270f490768e6d",
         description: "Description of the reward",
         explorer_url: "https://mumbai.polygonscan.com/address/0x124a6755ee787153bb6228463d5dc3a02890a7db"
     }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@
     - [Get deposit details for a user](#get-deposit-details-by-user-uid)
   - [Collection](#collection)
     - [Get a collection by UID](#get-a-collection-by-collection-uid)
+  - [Allocation](#allocation)
+    - [Create a new allocation](#create-a-new-allocation)
+    - [Get an allocation by allocation UID](#get-an-allocation-by-allocation-uid)
+    - [Get allocations by user UID](#get-allocations-by-user-uid)
+  - [Claim](#claim)
+    - [Create a new claim](#create-a-new-claim)
+    - [Get a claim by claim UID](#get-a-claim-by-claim-uid)
+    - [Get claims by user UID](#get-claims-by-user-uid)
+  - [Reward](#reward)
+    - [Get a reward by UID](#get-a-reward-by-reward-uid)
   - [Handling Errors](#handling-errors)
 
 ## ✨ Getting started
@@ -562,6 +572,179 @@ const collectionDetails = response.data;
         contract_address: "0x124a6755ee787153bb6228463d5dc3a02890a7db",
         symbol: "SYM",
         description: "Description of the collection",
+        explorer_url: "https://mumbai.polygonscan.com/address/0x124a6755ee787153bb6228463d5dc3a02890a7db"
+    }
+}
+```
+
+## Allocation
+
+The allocation methods exposed by the sdk are used to create and retrieve allocations from the Original API.
+
+### Create a new allocation
+
+```typescript
+// create a new allocation, by passing in the <AllocationParams> type
+// returns the uid of the newly created allocation
+const allocationParams: AllocationParams = {
+  amount: 123.123,
+  nonce: 'nonce1',
+  user_uid: userUid,
+  reward_uid: rewardUid,
+}
+const response = await client.createAllocation(allocationParams);
+const allocationUid = response.data.uid;
+// Sample response:
+{
+    success: true,
+    data: {
+        uid: "151854912345"
+    }
+}
+```
+
+### Get an allocation by allocation UID
+
+```typescript
+// gets an allocation by uid, will throw a 404 Not Found error if the allocation does not exist
+// returns a <Allocation> type
+const response = await client.getAllocation(allocationUid);
+const allocationDetails = response.data;
+// Sample response:
+{
+    success: true,
+    data: {
+        uid: "151854912345",
+        status: "done",
+        reward_uid: "reward_uid",
+        to_user_uid: "754566475542",
+        amount: 123.123,
+        nonce: "nonce1"
+        created_at: "2024-02-16T11:33:19.577827Z"
+    }
+}
+```
+
+### Get allocations by user UID
+
+```typescript
+// gets a list of allocations by user uid
+// will return a list of <Allocation>[] for the user
+const response = await client.getAllocationsByUserUid(userUid);
+const allocationsList = response.data;
+// Sample response:
+{
+    success: true,
+    data: [
+        {
+            uid: "151854912345",
+            status: "done",
+            reward_uid: "reward_uid",
+            to_user_uid: "754566475542",
+            amount: 123.123,
+            nonce: "nonce1"
+            created_at: "2024-02-16T11:33:19.577827Z"
+        }
+        // Additional allocations would be represented with similar structure here
+    ]
+}
+```
+
+## Claim
+
+The claim methods exposed by the sdk are used to create and retrieve claims from the Original API.
+
+### Create a new claim
+
+```typescript
+// create a new claim, by passing in the <ClaimParams> type
+// returns the uid of the newly created claim
+const claimParams: ClaimParams = {
+  from_user_uid: userUid,
+  reward_uid: reward_uid,
+  to_address: '0x4881ab2f73c48a54b907a8b697b270f490768e6d',
+}
+const response = await client.createClaim(claimParams);
+const claimUid = response.data.uid;
+// Sample response:
+{
+    success: true,
+    data: {
+        uid: "151854912345"
+    }
+}
+```
+
+### Get a claim by claim UID
+
+```typescript
+// gets a claim by uid, will throw a 404 Not Found error if the claim does not exist
+// returns a <Claim> type
+const response = await client.getClaim(claimUid);
+const claimDetails = response.data;
+// Sample response:
+{
+    success: true,
+    data: {
+        uid: "151854912345",
+        status: "done",
+        reward_uid: "708469717542",
+        from_user_uid: "754566475542",
+        to_address: "0x4881ab2f73c48a54b907a8b697b270f490768e6d",
+        amount: 123.123,
+        created_at: "2024-02-16T11:33:19.577827Z"
+    }
+}
+```
+
+### Get claims by user UID
+
+```typescript
+// gets a list of claims by user uid
+// will return a list of <Claim>[] for the user
+const response = await client.getClaimsByUserUid(userUid);
+const claimsList = response.data;
+// Sample response:
+{
+    success: true,
+    data: [
+        {
+            uid: "151854912345",
+            status: "done",
+            reward_uid: "708469717542",
+            from_user_uid: "754566475542",
+            to_address: "0x4881ab2f73c48a54b907a8b697b270f490768e6d",
+            amount: 123.123,
+            created_at: "2024-02-16T11:33:19.577827Z"
+        }
+        // Additional claims would be represented with similar structure here
+    ]
+}
+```
+
+## Reward
+
+The reward methods exposed by the sdk are used to retrieve reward details from the Original API.
+
+### Get a reward by reward UID
+
+```typescript
+// gets a reward by uid, will throw a 404 Not Found error if the reward does not exist
+// returns a <Reward> type
+const response = await client.getReward(rewardUid);
+const rewardDetails = response.data;
+// Sample response:
+{
+    success: true,
+    data: {
+        uid: "151854912345",
+        name: "Test SDK Reward 1",
+        status: "deployed",
+        token_type: "ERC20",
+        token_name: "TestnetORI",
+        created_at: "2024-02-13T10:45:56.952745Z",
+        contract_address: "0x124a6755ee787153bb6228463d5dc3a02890a7db",
+        description: "Description of the reward",
         explorer_url: "https://mumbai.polygonscan.com/address/0x124a6755ee787153bb6228463d5dc3a02890a7db"
     }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,11 @@ import {
   EditAssetParams,
   Deposit,
   BurnParams,
+  AllocationParams,
+  Allocation,
+  ClaimParams,
+  Claim,
+  Reward,
 } from './types';
 import { APIErrorResponse, isErrorResponse, throwErrorFromResponse } from './error';
 import { TokenManager } from './token_manager';
@@ -320,6 +325,85 @@ export class OriginalClient {
    */
   public async getDeposit(userUid: string) {
     return await this._get<APIResponse<Deposit>>('deposit', { user_uid: userUid });
+  }
+
+  /**
+   * reward methods
+   */
+
+  /**
+   * getReward
+   *
+   * @param {String} uid Uid of the reward to get
+   * @return {Promise<APIResponse<Reward>>} Returns the details of the reward.
+   * Will throw a 404 error if the reward does not exist.
+   */
+  public async getReward(uid: string) {
+    return this._get<APIResponse<Reward>>(`reward/${uid}`);
+  }
+
+  /**
+   * allocation methods
+   */
+
+  /**
+   * createAllocation
+   * @param {AllocationParams} allocation The details of the allocation to be created
+   * @return {Promise<APIResponse<UidResponse>>} Uid of the created allocation
+   */
+  public async createAllocation(allocation: AllocationParams) {
+    return await this._post<APIResponse<UidResponse>>('reward/allocate', allocation);
+  }
+
+  /**
+   * getAllocation
+   * @param {string} uid allocation uid to get
+   * @return {Promise<APIResponse<Allocation>>} Returns details of the allocation
+   * Will throw a 404 error if the allocation does not exist.
+   */
+  public async getAllocation(uid: string) {
+    return await this._get<APIResponse<Allocation>>(`reward/allocate/${uid}`);
+  }
+
+  /**
+   * listAllocations
+   * @param {string} userUid user_uid of allocations
+   * @return {Promise<APIResponse<Allocation[]>>} Returns a list of allocations available to the user, empty if none found
+   */
+  public async getAllocationsByUserUid(userUid: string) {
+    return await this._get<APIResponse<Allocation[] | null>>('reward/allocate', { user_uid: userUid });
+  }
+
+  /**
+   * claim methods
+   */
+
+  /**
+   * createClaim
+   * @param {ClaimParams} claim The details of the claim to be created
+   * @return {Promise<APIResponse<UidResponse>>} Uid of the created allocation
+   */
+  public async createClaim(claim: ClaimParams) {
+    return await this._post<APIResponse<UidResponse>>('reward/claim', claim);
+  }
+
+  /**
+   * getClaim
+   * @param {string} uid claim uid to get
+   * @return {Promise<APIResponse<Claim>>} Returns details of the allocation
+   * Will throw a 404 error if the allocation does not exist.
+   */
+  public async getClaim(uid: string) {
+    return await this._get<APIResponse<Claim>>(`reward/claim/${uid}`);
+  }
+
+  /**
+   * listClaims
+   * @param {string} userUid user_uid of claims
+   * @return {Promise<APIResponse<Claim[]>>} Returns a list of claims available to the user, empty if none found
+   */
+  public async getClaimsByUserUid(userUid: string) {
+    return await this._get<APIResponse<Claim[] | null>>('reward/claim', { user_uid: userUid });
   }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -295,7 +295,7 @@ export class OriginalClient {
    * @return {Promise<APIResponse<UidResponse>>} Returns the response object with the uid of the created burn.
    */
   public async createBurn(burn: BurnParams) {
-    return await this._post<APIResponse<UidResponse>>('burn', burn);
+    return this._post<APIResponse<UidResponse>>('burn', burn);
   }
 
   /**
@@ -305,7 +305,7 @@ export class OriginalClient {
    * Will throw a 404 error if the burn does not exist.
    */
   public async getBurn(uid: string) {
-    return await this._get<APIResponse<Burn>>(`burn/${uid}`);
+    return this._get<APIResponse<Burn>>(`burn/${uid}`);
   }
 
   /**
@@ -314,7 +314,7 @@ export class OriginalClient {
    * @return {Promise<APIResponse<Burn[]>>} Returns the response object with a list of burns made by the user. Returns an empty list if none found.
    */
   public async getBurnsByUserUid(userUid: string) {
-    return await this._get<APIResponse<Burn[] | null>>('burn', { user_uid: userUid });
+    return this._get<APIResponse<Burn[] | null>>('burn', { user_uid: userUid });
   }
 
   /**
@@ -324,7 +324,7 @@ export class OriginalClient {
    * Will throw a 404 error if the user does not exist.
    */
   public async getDeposit(userUid: string) {
-    return await this._get<APIResponse<Deposit>>('deposit', { user_uid: userUid });
+    return this._get<APIResponse<Deposit>>('deposit', { user_uid: userUid });
   }
 
   /**
@@ -352,7 +352,7 @@ export class OriginalClient {
    * @return {Promise<APIResponse<UidResponse>>} Uid of the created allocation
    */
   public async createAllocation(allocation: AllocationParams) {
-    return await this._post<APIResponse<UidResponse>>('reward/allocate', allocation);
+    return this._post<APIResponse<UidResponse>>('reward/allocate', allocation);
   }
 
   /**
@@ -362,7 +362,7 @@ export class OriginalClient {
    * Will throw a 404 error if the allocation does not exist.
    */
   public async getAllocation(uid: string) {
-    return await this._get<APIResponse<Allocation>>(`reward/allocate/${uid}`);
+    return this._get<APIResponse<Allocation>>(`reward/allocate/${uid}`);
   }
 
   /**
@@ -371,7 +371,7 @@ export class OriginalClient {
    * @return {Promise<APIResponse<Allocation[]>>} Returns a list of allocations available to the user, empty if none found
    */
   public async getAllocationsByUserUid(userUid: string) {
-    return await this._get<APIResponse<Allocation[] | null>>('reward/allocate', { user_uid: userUid });
+    return this._get<APIResponse<Allocation[] | null>>('reward/allocate', { user_uid: userUid });
   }
 
   /**
@@ -384,7 +384,7 @@ export class OriginalClient {
    * @return {Promise<APIResponse<UidResponse>>} Uid of the created allocation
    */
   public async createClaim(claim: ClaimParams) {
-    return await this._post<APIResponse<UidResponse>>('reward/claim', claim);
+    return this._post<APIResponse<UidResponse>>('reward/claim', claim);
   }
 
   /**
@@ -394,7 +394,7 @@ export class OriginalClient {
    * Will throw a 404 error if the allocation does not exist.
    */
   public async getClaim(uid: string) {
-    return await this._get<APIResponse<Claim>>(`reward/claim/${uid}`);
+    return this._get<APIResponse<Claim>>(`reward/claim/${uid}`);
   }
 
   /**
@@ -403,7 +403,7 @@ export class OriginalClient {
    * @return {Promise<APIResponse<Claim[]>>} Returns a list of claims available to the user, empty if none found
    */
   public async getClaimsByUserUid(userUid: string) {
-    return await this._get<APIResponse<Claim[] | null>>('reward/claim', { user_uid: userUid });
+    return this._get<APIResponse<Claim[] | null>>('reward/claim', { user_uid: userUid });
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export type AssetMetadata = {
   attributes?: { trait_type: string; value: string; display_type?: string }[];
   description?: string;
   external_url?: string;
-}
+};
 
 export type Asset = {
   collection_name: string;
@@ -106,6 +106,51 @@ export type Burn = {
   created_at: string;
   from_user_uid: string;
   status: string;
+  uid: string;
+};
+
+export type Reward = {
+  contract_address: string;
+  created_at: string;
+  description: string;
+  explorer_url: string;
+  name: string;
+  status: string;
+  token_name: string;
+  token_type: string;
+  uid: string;
+};
+
+export type AllocationParams = {
+  amount: number;
+  nonce: string;
+  reward_uid: string;
+  to_user_uid: string;
+};
+
+export type Allocation = {
+  amount: number;
+  created_at: string;
+  nonce: string;
+  reward_uid: string;
+  status: string;
+  to_user_uid: string;
+  uid: string;
+};
+
+export type ClaimParams = {
+  from_user_uid: string;
+  reward_uid: string;
+  to_address: string;
+};
+
+export type Claim = {
+  amount: number;
+  created_at: string;
+  from_user_uid: string;
+  reward_uid: string;
+  status: string;
+  to_address: string;
   uid: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,7 @@ export type Reward = {
   token_name: string;
   token_type: string;
   uid: string;
+  withdraw_receiver: string;
 };
 
 export type AllocationParams = {


### PR DESCRIPTION
## Why
Update sdk to include new endpoints for the reward api
### How
- add reward methods (get)
- add allocation methods (post, get_by_uid, get_by_user_uid)
- add claim method (post, get_by_uid, get_by_user_uid)
### How Has This Been Tested?
e2e tests
