### PR TITLE
fix(ORI-2200): add external ids to user and asset and deprecate client_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     - [Create a new user](#create-a-new-user)
     - [Get a user by UID](#get-a-user-by-uid)
     - [Get a user by email](#get-a-user-by-email)
-    - [Get a user by client ID](#get-a-user-by-client-id)
+    - [Get a user by user external ID](#get-a-user-by-user-external-id)
   - [Asset](#asset)
     - [Create a new asset](#create-a-new-asset)
     - [Get an asset by UID](#get-an-asset-by-asset-uid)
@@ -111,9 +111,9 @@ const userUid = response.data.uid;
     }
 }
 
-// You can also pass in a client_id and/or email for your external reference.
-// The client ID and/or email supplied must be unique per app
-const response = await client.createUser({ client_id: 'YOUR_CLIENT_ID', email: 'YOUR_EMAIL' });
+// You can also pass in a user_external_id and/or email for your external reference.
+// The user external ID and/or email supplied must be unique per app
+const response = await client.createUser({ user_external_id: 'YOUR_USER_EXTERNAL_ID', email: 'YOUR_EMAIL' });
 const userUid = response.data.uid;
 // ...
 ```
@@ -130,7 +130,7 @@ const userDetails = response.data;
     success: true,
     data: {
         uid: "754566475542",
-        client_id: "user_client_id",
+        user_external_id: "user_external_id",
         created_at: "2024-02-26T13:12:31.798296Z",
         email: "user_email@email.com",
         wallet_address: "0xa22f2dfe189ed3d16bb5bda5e5763b2919058e40"
@@ -150,7 +150,7 @@ const userDetails = response.data;
     success: true,
     data: {
         uid: "754566475542",
-        client_id: "user_client_id",
+        user_external_id: "user_external_id",
         created_at: "2024-02-26T13:12:31.798296Z",
         email: "user_email@email.com",
         wallet_address: "0xa22f2dfe189ed3d16bb5bda5e5763b2919058e40"
@@ -164,19 +164,19 @@ const userDetails = response.data;
 }
 ```
 
-### Get a user by client ID
+### Get a user by user external ID
 
 ```typescript
-// Get a user by client ID
-// Retrieves a user by their client ID. If the user does not exist, `data` will be null.
-const response = await client.getUserByClientId('YOUR_CLIENT_ID');
-const userByClientId = response.data;
+// Get a user by user external ID
+// Retrieves a user by their user external ID. If the user does not exist, `data` will be null.
+const response = await client.getUserByUserExternalId('YOUR_USER_EXTERNAL_ID');
+const userByUserExternalId = response.data;
 // Sample response on success
 {
     success: true,
     data: {
         uid: "754566475542",
-        client_id: "user_client_id",
+        user_external_id: "user_external_id",
         created_at: "2024-02-26T13:12:31.798296Z",
         email: "user_email@email.com",
         wallet_address: "0xa22f2dfe189ed3d16bb5bda5e5763b2919058e40"
@@ -200,7 +200,7 @@ The asset methods exposed by the sdk are used to create (mint) assets and retrie
 const newAssetParams: AssetParams =
 {
     user_uid: "324167489835",
-    client_id: "client_id_1",
+    asset_external_id: "asset_external_id_1",
     collection_uid: "221137489875",
     data: {
         name: "Dave Starbelly",
@@ -258,7 +258,7 @@ const asset = response.data;
     data: {
         uid: "151854912345",
         name: "random name #2",
-        client_id: "asset_client_id_1",
+        asset_external_id: "asset_external_id_1",
         collection_uid: "471616646163",
         collection_name: "Test SDK Collection 1",
         token_id: 2,
@@ -306,7 +306,7 @@ const assetList = response.data;
         {
             uid: "151854912345",
             name: "random name #2",
-            client_id: "asset_client_id_1",
+            asset_external_id: "asset_external_id_1",
             collection_uid: "471616646163",
             collection_name: "Test SDK Collection 1",
             token_id: 2,
@@ -567,7 +567,7 @@ const collectionDetails = response.data;
 }
 ```
 
-### Handling Errors
+## Handling Errors
 
 If something goes wrong, you will receive well typed error messages.
 
@@ -600,7 +600,7 @@ So when an error occurs, you can either catch all using the OriginalError class:
 import { OriginalError } from 'original-sdk';
 
 try {
-  client.createUser('client_id', 'invalid_email');
+  client.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' });
 } catch (error: unknown) {
   if (error instanceof OriginalError) {
     // handle all errors
@@ -614,7 +614,7 @@ or specific errors:
 import { ClientError, ServerError, ValidationError } from 'original-sdk';
 
 try {
-  client.createUser('client_id', 'invalid_email');
+  client.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' });
 } catch (error: unknown) {
   if (error instanceof ClientError) {
     // handle client errors

--- a/src/client.ts
+++ b/src/client.ts
@@ -178,6 +178,8 @@ export class OriginalClient {
   }
 
   /**
+   * @deprecated getUserByClientId. Please use `getUserByUserExternalId` instead.
+   * 
    * getUserByClientId
    *
    * @param {String} clientId ClientId of the user to get
@@ -186,6 +188,17 @@ export class OriginalClient {
    */
   public async getUserByClientId(clientId: string) {
     return this._get<APIResponse<User | null>>('user', { client_id: clientId });
+  }
+
+  /**
+   * getUserByUserExternalId
+   *
+   * @param {String} userExternalId UserExternalId of the user to get
+   * @return {Promise<APIResponse<User | null>>} Returns the response object with the details of the user,
+   * or null data if not found.
+   */
+  public async getUserByUserExternalId(userExternalId: string) {
+    return this._get<APIResponse<User | null>>('user', { user_external_id: userExternalId });
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -179,7 +179,7 @@ export class OriginalClient {
 
   /**
    * @deprecated getUserByClientId. Please use `getUserByUserExternalId` instead.
-   * 
+   *
    * getUserByClientId
    *
    * @param {String} clientId ClientId of the user to get

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,26 @@ export type OriginalOptions = AxiosRequestConfig & {
   env?: Environment;
 };
 
-export type UserParams = { client_id?: string; email?: string };
+export type UserParams = {
+  /**
+   * @deprecated client_id. Please use `user_external_id` instead.
+  */
+  client_id?: string; 
+  email?: string, 
+  user_external_id?: string; 
+};
 
-export type User = { client_id: string; created_at: string; email: string; uid: string; wallet_address: string };
+export type User = { 
+  created_at: string; 
+  email: string; 
+  uid: string; 
+  wallet_address: string; 
+  /**
+   * @deprecated client_id. Please use `user_external_id` instead.
+   */
+  client_id?: string; 
+  user_external_id?: string; 
+};
 
 export type Collection = {
   contract_address: string;
@@ -34,7 +51,11 @@ export type AssetParams = {
   collection_uid: string;
   data: AssetData;
   user_uid: string;
+  /**
+   * @deprecated client_id. Please use `user_external_id` instead.
+   */
   client_id?: string;
+  user_external_id?: string;
 };
 
 export type EditAssetData = {
@@ -73,6 +94,10 @@ export type Asset = {
   name: string;
   token_id: string;
   uid: string;
+  asset_external_id?: string | null;
+  /**
+   * @deprecated client_id. Please use `asset_external_id` instead.
+  */
   client_id?: string | null;
   explorer_url?: string;
   metadata?: string | AssetMetadata;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,11 +51,11 @@ export type AssetParams = {
   collection_uid: string;
   data: AssetData;
   user_uid: string;
+  asset_external_id?: string;
   /**
-   * @deprecated client_id. Please use `user_external_id` instead.
+   * @deprecated client_id. Please use `asset_external_id` instead.
    */
   client_id?: string;
-  user_external_id?: string;
 };
 
 export type EditAssetData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,22 +7,22 @@ export type OriginalOptions = AxiosRequestConfig & {
 export type UserParams = {
   /**
    * @deprecated client_id. Please use `user_external_id` instead.
-  */
-  client_id?: string; 
-  email?: string, 
-  user_external_id?: string; 
+   */
+  client_id?: string;
+  email?: string;
+  user_external_id?: string;
 };
 
-export type User = { 
-  created_at: string; 
-  email: string; 
-  uid: string; 
-  wallet_address: string; 
+export type User = {
+  created_at: string;
+  email: string;
+  uid: string;
+  wallet_address: string;
   /**
    * @deprecated client_id. Please use `user_external_id` instead.
    */
-  client_id?: string; 
-  user_external_id?: string; 
+  client_id?: string;
+  user_external_id?: string;
 };
 
 export type Collection = {
@@ -79,7 +79,7 @@ export type AssetMetadata = {
   attributes?: { trait_type: string; value: string; display_type?: string }[];
   description?: string;
   external_url?: string;
-}
+};
 
 export type Asset = {
   collection_name: string;
@@ -97,7 +97,7 @@ export type Asset = {
   asset_external_id?: string | null;
   /**
    * @deprecated client_id. Please use `asset_external_id` instead.
-  */
+   */
   client_id?: string | null;
   explorer_url?: string;
   metadata?: string | AssetMetadata;

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -44,7 +44,7 @@ describe('Original sdk e2e-method tests', async () => {
 
 	it('gets user by user_external_id', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
-		const response = await original.getuserByUserExternalId(mintToUserClientId);
+		const response = await original.getUserByUserExternalId(mintToUserClientId);
 		expect(response.data.email).to.equal(mintToUserEmail);
 	});
 

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -26,6 +26,7 @@ describe('Original sdk e2e-method tests', async () => {
 	it('gets user by uid', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getUser(mintToUserUid);
+		expect(response.data.user_external_id).to.equal(mintToUserClientId);
 		expect(response.data.client_id).to.equal(mintToUserClientId);
 	});
 
@@ -38,6 +39,12 @@ describe('Original sdk e2e-method tests', async () => {
 	it('gets user by client_id', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getUserByClientId(mintToUserClientId);
+		expect(response.data.email).to.equal(mintToUserEmail);
+	});
+
+	it('gets user by user_external_id', async () => {
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const response = await original.getuserByUserExternalId(mintToUserClientId);
 		expect(response.data.email).to.equal(mintToUserEmail);
 	});
 
@@ -76,6 +83,16 @@ describe('Original sdk e2e-method tests', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.createUser({
 			email: `${clientId}@test.com`,
+			user_external_id: clientId,
+		});
+		expect(response.data.uid).to.exist;
+	});
+
+	it('creates user with deprecated client_id', async () => {
+		const clientId = randomString.generate(8);
+		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
+		const response = await original.createUser({
+			email: `${clientId}@test.com`,
 			client_id: clientId,
 		});
 		expect(response.data.uid).to.exist;
@@ -93,7 +110,7 @@ describe('Original sdk e2e-method tests', async () => {
 		try {
 			await original.createUser({
 				email: `invalid_email`,
-				client_id: clientId,
+				user_external_id: clientId,
 			});
 			expect.fail('createUser should have thrown an error');
 		} catch (error) {
@@ -110,7 +127,7 @@ describe('Original sdk e2e-method tests', async () => {
 		try {
 			await original.createUser({
 				email: `${clientId}@test.com`,
-				client_id: clientId,
+				user_external_id: clientId,
 			});
 			expect.fail('createUser should have thrown an error');
 		} catch (error) {
@@ -140,7 +157,7 @@ describe('Original sdk e2e-method tests', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const userResponse = await original.createUser({
 			email: `${clientId}@test.com`,
-			client_id: clientId,
+			user_external_id: clientId,
 		});
 		const response = await original.getAssetsByUserUid(userResponse.data.uid);
 		expect(response.data.length).to.equal(0);
@@ -182,7 +199,7 @@ describe('Original sdk e2e-method tests', async () => {
 		expect(response.data.chain_id).to.equal(ACCEPTANCE_CHAIN_ID);
 	});
 
-	it('creates an asset without client id', async () => {
+	it('creates an asset without client id or asset_external_id', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const assetName = randomString.generate(8);
 		const asset_data = {
@@ -223,7 +240,7 @@ describe('Original sdk e2e-method tests', async () => {
 		const request_data = {
 			data: asset_data,
 			user_uid: mintToUserUid,
-			client_id: assetName,
+			asset_external_id: assetName,
 			collection_uid: editableCollectionUid,
 		};
 		const assetResponse = await original.createAsset(request_data);
@@ -259,7 +276,7 @@ describe('Original sdk e2e-method tests', async () => {
 		const request_data = {
 			data: asset_data,
 			user_uid: mintToUserUid,
-			client_id: assetName,
+			asset_external_id: assetName,
 			collection_uid: editableCollectionUid,
 		};
 		const assetResponse = await original.createAsset(request_data);

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -79,7 +79,9 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ClientError);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(ClientError);
 	});
 
 	it('throws ServerError on server error response', async () => {
@@ -96,7 +98,9 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ServerError);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(ServerError);
 	});
 
 	it('throws ValidationError on validation error response', async () => {
@@ -113,7 +117,9 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ValidationError);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(ValidationError);
 	});
 
 	it('correctly extracts error message from response detail', async () => {
@@ -141,7 +147,9 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects(new Error('Network Error'));
 
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(Error);
 	});
 
 	it('throws an error on request timeout', async () => {
@@ -150,7 +158,9 @@ describe('Original client error management tests', () => {
 			.stub(original.axiosInstance, 'post')
 			.rejects({ code: 'ECONNABORTED', message: 'timeout of 0ms exceeded' });
 
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(Error);
 	});
 
 	it('handles unexpected status codes', async () => {
@@ -164,7 +174,9 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(Error);
 	});
 
 	it('can make a successful request after handling an error', async () => {
@@ -180,10 +192,13 @@ describe('Original client error management tests', () => {
 			.resolves({ status: 200, data: { success: true } });
 
 		// Expect the first call to fail
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ServerError);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(ServerError);
 
 		// Expect the second call to succeed
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.fulfilled;
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' })).to
+			.eventually.be.fulfilled;
 	});
 
 	it('handles errors without a response body gracefully', async () => {
@@ -195,6 +210,8 @@ describe('Original client error management tests', () => {
 
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
+		await expect(
+			original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email' }),
+		).to.eventually.be.rejectedWith(Error);
 	});
 });

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -79,7 +79,7 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(ClientError);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ClientError);
 	});
 
 	it('throws ServerError on server error response', async () => {
@@ -96,7 +96,7 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(ServerError);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ServerError);
 	});
 
 	it('throws ValidationError on validation error response', async () => {
@@ -113,7 +113,7 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(ValidationError);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ValidationError);
 	});
 
 	it('correctly extracts error message from response detail', async () => {
@@ -141,7 +141,7 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects(new Error('Network Error'));
 
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(Error);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
 	});
 
 	it('throws an error on request timeout', async () => {
@@ -150,7 +150,7 @@ describe('Original client error management tests', () => {
 			.stub(original.axiosInstance, 'post')
 			.rejects({ code: 'ECONNABORTED', message: 'timeout of 0ms exceeded' });
 
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(Error);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
 	});
 
 	it('handles unexpected status codes', async () => {
@@ -164,7 +164,7 @@ describe('Original client error management tests', () => {
 		const original = new OriginalClient('apiKey', 'apiSecret');
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(Error);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
 	});
 
 	it('can make a successful request after handling an error', async () => {
@@ -180,10 +180,10 @@ describe('Original client error management tests', () => {
 			.resolves({ status: 200, data: { success: true } });
 
 		// Expect the first call to fail
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(ServerError);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(ServerError);
 
 		// Expect the second call to succeed
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.fulfilled;
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.fulfilled;
 	});
 
 	it('handles errors without a response body gracefully', async () => {
@@ -195,6 +195,6 @@ describe('Original client error management tests', () => {
 
 		sandbox.stub(original.axiosInstance, 'post').rejects({ response: mockResponse });
 
-		await expect(original.createUser('client_id', 'email')).to.eventually.be.rejectedWith(Error);
+		await expect(original.createUser({ user_external_id: 'user_external_id', email: 'invalid_email'})).to.eventually.be.rejectedWith(Error);
 	});
 });


### PR DESCRIPTION
## Why
- Client ID has been deprecated. We should now use user_external_id and asset_external_id

### How
- Add relevant params
- Deprecate wherever we use client_id
- Added getUserByUserExternalId function

### How Has This Been Tested?
- Locally
- Via demo

## Checklist
<img width="1142" alt="Screenshot 2024-03-11 at 12 46 58" src="https://github.com/getoriginal/original-js/assets/10096212/930b6fb5-fb74-47ca-b723-91660230884e">
