### PR TITLE
chore(release):v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.3](https://github.com/getoriginal/original-js/compare/v1.2.2...v1.2.3) (2024-03-12)
+
+
+### Bug Fixes
+
+* **ORI-2200:** add external ids to user and asset and deprecate client_id ([3b61540](https://github.com/getoriginal/original-js/commit/3b61540cf54a82ce76969ce032e1528b8d8b26e6))
+
+
 ### [1.2.2](https://github.com/getoriginal/original-js/compare/v1.2.1...v1.2.2) (2024-03-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "original-sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Original SDK for js",
   "repository": "https://github.com/getoriginal/original-js.git",
   "author": "Original",


### PR DESCRIPTION
## Why
- Release v1.2.3

### How
- Deprecate client_id. Add support for external_ids in asset and user

