### PR TITLE
fix: move chain logic to env and reuse some env vars in e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -30,11 +30,11 @@ jobs:
           TRANSFER_TO_USER_WALLET: ${{secrets.TRANSFER_TO_USER_WALLET}}
           TRANSFER_TO_USER_UID: ${{secrets.TRANSFER_TO_USER_UID}}
           ASSET_UID: ${{secrets.ASSET_UID}}
-          NON_EDITABLE_COLLECTION_UID: ${{secrets.NON_EDITABLE_COLLECTION_UID}}
           ALLOCATION_UID: ${{secrets.ALLOCATION_UID}}
           CLAIM_UID: ${{secrets.CLAIM_UID}}
           REWARD_UID: ${{secrets.REWARD_UID}}
-          USER_UID: ${{secrets.USER_UID}}
           CLAIM_TO_ADDRESS: ${{secrets.CLAIM_TO_ADDRESS}}
           EDITABLE_COLLECTION_UID: ${{secrets.EDITABLE_COLLECTION_UID}}
           ACCEPTANCE_ENDPOINT: ${{secrets.ACCEPTANCE_ENDPOINT}}
+          ACCEPTANCE_CHAIN_ID: ${{secrets.ACCEPTANCE_CHAIN_ID}}
+          ACCEPTANCE_NETWORK: ${{secrets.ACCEPTANCE_NETWORK}}

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -7,6 +7,7 @@ const expect = chai.expect;
 chai.use(chaiAsPromised);
 require('dotenv').config({ path: `${process.cwd()}/test/e2e/.env` });
 
+const RETRY_COUNT = 10;
 describe('Original sdk e2e-method tests', async () => {
 	const acceptanceChainId = process.env.ACCEPTANCE_CHAIN_ID;
 	const acceptanceNetwork = process.env.ACCEPTANCE_NETWORK;
@@ -291,7 +292,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let assetIsTransferable = false;
 		let retries = 0;
 		// wait for asset to be transferable
-		while (!assetIsTransferable && retries < 20) {
+		while (!assetIsTransferable && retries < RETRY_COUNT) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const asset = await original.getAsset(assetUid);
 			assetIsTransferable = asset.data.is_transferable;
@@ -327,7 +328,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let assetIsTransferable = false;
 		let retries = 0;
 		// wait for asset to be transferable
-		while (!assetIsTransferable && retries < 10) {
+		while (!assetIsTransferable && retries < RETRY_COUNT) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const asset = await original.getAsset(assetUid);
 			assetIsTransferable = asset.data.is_transferable;
@@ -343,7 +344,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let isTransferring = true;
 		retries = 0;
 		// wait for transfer to be done
-		while (isTransferring && retries < 10) {
+		while (isTransferring && retries < RETRY_COUNT) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const asset = await original.getAsset(assetUid);
 			isTransferring = asset.data.is_transferring;
@@ -359,7 +360,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let isBurning = true;
 		retries = 0;
 		// wait for burn to be done
-		while (isBurning && retries < 10) {
+		while (isBurning && retries < RETRY_COUNT) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const burn = await original.getBurn(burnUid);
 			isBurning = burn.data.status !== 'done';
@@ -370,7 +371,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let finalAssetBurnStatus = false;
 		retries = 0;
 		// there is a delay between when the burn is done and when the asset is burned field is updated
-		while (!finalAssetBurnStatus && retries < 10) {
+		while (!finalAssetBurnStatus && retries < RETRY_COUNT) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const finalAsset = await original.getAsset(assetUid);
 			finalAssetBurnStatus = finalAsset.data.is_burned;
@@ -392,7 +393,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let isAllocating = true;
 		let retries = 0;
 		// wait for allocation to be done
-		while (isAllocating && retries < 10) {
+		while (isAllocating && retries < RETRY_COUNT) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const allocation = await original.getAllocation(allocationUid);
 			isAllocating = allocation.data.status !== 'done';
@@ -409,7 +410,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let isClaiming = true;
 		retries = 0;
 		// wait for claim to be done
-		while (isClaiming && retries < 10) {
+		while (isClaiming && retries < RETRY_COUNT) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const claim = await original.getClaim(claimUid);
 			isClaiming = claim.data.status !== 'done';

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -7,9 +7,9 @@ const expect = chai.expect;
 chai.use(chaiAsPromised);
 require('dotenv').config({ path: `${process.cwd()}/test/e2e/.env` });
 
-const ACCEPTANCE_CHAIN_ID = 80001;
-const ACCEPTANCE_NETWORK = 'Mumbai';
 describe('Original sdk e2e-method tests', async () => {
+	const acceptanceChainId = process.env.ACCEPTANCE_CHAIN_ID;
+	const acceptanceNetwork = process.env.ACCEPTANCE_NETWORK;
 	const apiKey = process.env.API_KEY;
 	const apiSecret = process.env.API_SECRET;
 	const mintToUserUid = process.env.MINT_TO_USER_UID;
@@ -19,12 +19,10 @@ describe('Original sdk e2e-method tests', async () => {
 	const transferToUserWallet = process.env.TRANSFER_TO_USER_WALLET;
 	const transferToUserUid = process.env.TRANSFER_TO_USER_UID;
 	const getAssetUid = process.env.ASSET_UID;
-	const nonEditableCollectionUid = process.env.NON_EDITABLE_COLLECTION_UID;
 	const editableCollectionUid = process.env.EDITABLE_COLLECTION_UID;
 	const getAllocationUid = process.env.ALLOCATION_UID;
 	const getClaimUid = process.env.CLAIM_UID;
 	const rewardUid = process.env.REWARD_UID;
-	const userUid = process.env.USER_UID;
 	const claimToAddress = process.env.CLAIM_TO_ADDRESS;
 	const acceptanceEndpoint = process.env.ACCEPTANCE_ENDPOINT;
 
@@ -198,16 +196,16 @@ describe('Original sdk e2e-method tests', async () => {
 
 	it('get collection', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
-		const response = await original.getCollection(nonEditableCollectionUid);
-		expect(response.data.uid).to.equal(nonEditableCollectionUid);
+		const response = await original.getCollection(editableCollectionUid);
+		expect(response.data.uid).to.equal(editableCollectionUid);
 	});
 
 	it('get deposit address', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const response = await original.getDeposit(transferToUserUid);
 		expect(response.data.wallet_address).to.equal(transferToUserWallet);
-		expect(response.data.network).to.equal(ACCEPTANCE_NETWORK);
-		expect(response.data.chain_id).to.equal(ACCEPTANCE_CHAIN_ID);
+		expect(response.data.network).to.equal(acceptanceNetwork);
+		expect(response.data.chain_id).to.equal(parseInt(acceptanceChainId));
 	});
 
 	it('get reward', async () => {
@@ -293,7 +291,7 @@ describe('Original sdk e2e-method tests', async () => {
 		let assetIsTransferable = false;
 		let retries = 0;
 		// wait for asset to be transferable
-		while (!assetIsTransferable && retries < 10) {
+		while (!assetIsTransferable && retries < 20) {
 			await new Promise((resolve) => setTimeout(resolve, 20000));
 			const asset = await original.getAsset(assetUid);
 			assetIsTransferable = asset.data.is_transferable;
@@ -388,7 +386,7 @@ describe('Original sdk e2e-method tests', async () => {
 			amount: 0.001,
 			nonce: randomString.generate(8),
 			reward_uid: rewardUid,
-			to_user_uid: userUid,
+			to_user_uid: mintToUserUid,
 		});
 		const allocationUid = allocationResponse.data.uid;
 		let isAllocating = true;
@@ -403,7 +401,7 @@ describe('Original sdk e2e-method tests', async () => {
 		const allocation = await original.getAllocation(allocationUid);
 		expect(allocation.data.status).to.equal('done');
 		const claimResponse = await original.createClaim({
-			from_user_uid: userUid,
+			from_user_uid: mintToUserUid,
 			reward_uid: rewardUid,
 			to_address: claimToAddress,
 		});


### PR DESCRIPTION
## Why
Should not hardcode expected chainID and network, move to .env
### How
- add .env for CHAIN_ID and NETWORK
- cleanup some existing env vars to reuse existing ones

### How Has This Been Tested?
e2e tests passing
### Checklist
