### PR TITLE
fix(ori-2607): update readme get asset apis image_url -> image

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ const asset = response.data;
         owner_address: "0x32e28bfe647939d073d39113c697a11e3065ea97",
         metadata: {
             name: "random name",
-            image_url: "https://cryptopunks.app/cryptopunks/cryptopunk1081.png",
+            image: "https://cryptopunks.app/cryptopunks/cryptopunk1081.png",
             description: "nft_description",
             original_id: "151854912345",
             external_url: "external_url@example.com",
@@ -332,7 +332,7 @@ const assetList = response.data;
             owner_address: "0x32e28bfe647939d073d39113c697a11e3065ea97",
             metadata: {
                 name: "random name",
-                image_url: "https://cryptopunks.app/cryptopunks/cryptopunk1081.png",
+                image: "https://cryptopunks.app/cryptopunks/cryptopunk1081.png",
                 description: "nft_description",
                 original_id: "151854912345",
                 external_url: "external_url@example.com",

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export type EditAssetParams = {
 };
 
 export type AssetMetadata = {
-  image_url: string;
+  image: string;
   name: string;
   org_image_url: string;
   original_id: string;


### PR DESCRIPTION
## Why
- `image_url` has become `image` in the asset metadata

### How
- Update docs

### How Has This Been Tested?

### Checklist
