### PR TITLE
fix:(ori-2666) - remove client_id, make asset_external_id required

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -48,14 +48,10 @@ export type AssetData = {
 };
 
 export type AssetParams = {
+  asset_external_id: string;
   collection_uid: string;
   data: AssetData;
   user_uid: string;
-  asset_external_id?: string;
-  /**
-   * @deprecated client_id. Please use `asset_external_id` instead.
-   */
-  client_id?: string;
   sale_price_in_usd?: number;
 };
 
@@ -83,6 +79,7 @@ export type AssetMetadata = {
 };
 
 export type Asset = {
+  asset_external_id: string;
   collection_name: string;
   collection_uid: string;
   created_at: string;
@@ -95,11 +92,6 @@ export type Asset = {
   name: string;
   token_id: string;
   uid: string;
-  asset_external_id?: string | null;
-  /**
-   * @deprecated client_id. Please use `asset_external_id` instead.
-   */
-  client_id?: string | null;
   explorer_url?: string;
   metadata?: string | AssetMetadata;
   owner_address?: string;

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -396,30 +396,6 @@ describe('Original sdk e2e-method tests', async () => {
 		expect(claim.data.status).to.equal('done');
 	});
 
-	it('creates an asset without client id or asset_external_id', async () => {
-		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
-		const assetName = randomString.generate(8);
-		const asset_data = {
-			name: assetName,
-			unique_name: true,
-			image_url: 'https://example.com/image.png',
-			store_image_on_ipfs: false,
-			description: 'test description',
-			attributes: [
-				{ trait_type: 'Eyes', value: 'Green' },
-				{ trait_type: 'Hair', value: 'Black' },
-			],
-		};
-		const request_data = {
-			data: asset_data,
-			user_uid: mintToUserUid,
-			collection_uid: editableCollectionUid,
-		};
-		const assetResponse = await original.createAsset(request_data);
-		const assetUid = assetResponse.data.uid;
-		expect(assetUid).to.exist;
-	});
-
 	it('creates an asset with a mint price', async () => {
 		const original = new OriginalClient(apiKey, apiSecret, { baseURL: acceptanceEndpoint });
 		const assetName = randomString.generate(8);
@@ -438,6 +414,7 @@ describe('Original sdk e2e-method tests', async () => {
 		const request_data = {
 			data: asset_data,
 			user_uid: mintToUserUid,
+			asset_external_id: assetName,
 			collection_uid: editableCollectionUid,
 		};
 		const assetResponse = await original.createAsset(request_data);


### PR DESCRIPTION
## Why
- asset_external_id is now required

### How
- Remove deprecated client_id
- Remove optional marker on asset_external_id
- Remove test

### How Has This Been Tested?
- Locally

### Checklist
